### PR TITLE
sbsigntool: fix cross compilation flags contamination

### DIFF
--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool/0001-create-ccan-tree-use-native-tools.patch
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool/0001-create-ccan-tree-use-native-tools.patch
@@ -1,0 +1,44 @@
+From ff049c6ceb557efbaed3c4b209872d851c620f4a Mon Sep 17 00:00:00 2001
+From: Guillaume Champagne <champagne.guillaume.c@gmail.com>
+Date: Mon, 20 Feb 2023 13:48:18 -0500
+Subject: [PATCH] tools: create-ccan-tree: use native tools built by yocto
+
+If tools are built during the target build the compilation flags may be
+incompatible with the host. Thus, assume yocto pre-built the necessary
+binaries and use them as is.
+---
+ tools/create-ccan-tree | 18 ++++++------------
+ 1 file changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/tools/create-ccan-tree b/tools/create-ccan-tree
+index 64fc36e7..46f86a81 100755
+--- a/lib/ccan.git/tools/create-ccan-tree
++++ b/lib/ccan.git/tools/create-ccan-tree
+@@ -82,18 +82,12 @@ tmpdir="$(mktemp -d)"
+ # sanity check, we don't want to be overwriting stuff in arbitrary dirs
+ [ $? -eq 0 -a -d "${tmpdir}" ] || exit 1
+ 
+-# We'll need the ccan_depends tool, but also a clean source tree. Build
+-# tools/ccan_depends, and store it in $tmpdir for later use
+-
+-echo "Building ccan_depends"
+-ccan_depends="$tmpdir/ccan_depends"
+-make -s -C "$srcdir" tools/ccan_depends
+-[ $? -eq 0 ] || exit 1
+-cp "$srcdir/tools/ccan_depends" "$ccan_depends"
+-
+-echo "Cleaning source tree"
+-make -s -C "$srcdir" clean
+-[ $? -eq 0 ] || exit 1
++# We assume ccan_depends was pre-built by yocto
++if [ ! -e ${srcdir}/tools/ccan_depends ]
++then
++	echo "tools/ccan_depends not built" >&2
++	exit 1
++fi
+ 
+ # clean up on error
+ trap 'rm -rf $tmpdir' EXIT
+-- 
+2.30.2
+


### PR DESCRIPTION
Hi all,

as mentioned in the commit message I am hitting a bug when cross compiling `sbsigntool`. Tools compiled during the configuration stage and used on the host  have the interpreter set wrong. It points to the target interpreter which doesn't exist on the host. Even if I were to manually patch the elf to point to the correct interpreter (patchelf), I assume that the binaries compiled with the target compilation arguments may not even run correctly on the host since I'm compiling for a zen3 AMD processor from an intel CPU.

The proposed solution feels a bit hackish since I'm manually copying the tools into the build directory... a simpler solution may exist.

Best,
Guillaume 