### PR TITLE
meta: add signing-key to LAYERDEPENDS

### DIFF
--- a/meta/conf/layer.conf
+++ b/meta/conf/layer.conf
@@ -13,6 +13,7 @@ BBLAYERS_LAYERINDEX_NAME_secure-core = "meta-secure-core"
 
 LAYERDEPENDS_secure-core = "\
     core \
+    signing-key \
 "
 
 LAYERSERIES_COMPAT_secure-core = "mickledore"


### PR DESCRIPTION
Add signing-key layer to LAYERDEPENDS to fix the below yocto compliance issue:
 INFO: ERROR: test_world (common.CommonCheckLayer)
 INFO: ----------------------------------------------------------------------
 INFO: Traceback (most recent call last):
  File "/build/layers/oe-core/scripts/lib/checklayer/cases/common.py", line 58, in test_world
    get_signatures(self.td['builddir'], failsafe=False)
  File "/build/layers/oe-core/scripts/lib/checklayer/__init__.py", line 315, in get_signatures
    check_command('Generating signatures failed. This might be due to some parse error and/or general layer incompatibilities.',
  File "/build/layers/oe-core/scripts/lib/checklayer/__init__.py", line 287, in check_command
    raise RuntimeError(msg)
 RuntimeError: Generating signatures failed. This might be due to some parse error and/or general layer incompatibilities.
 Command: BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS BB_SIGNATURE_HANDLER" BB_SIGNATURE_HANDLER="OEBasicHash" bitbake -S none world
Output:
 Loading cache...done.
 Loaded 22 entries from dependency cache.
 Parsing recipes...ERROR: ParseError at /build/layers/meta-secure-core/meta/recipes-core/images/secure-core-image-initramfs.bb:30: Could not inherit file classes/user-key-store.bbclass
 ERROR: Parsing halted due to errors, see error messages above

Summary: There were 2 ERROR messages, returning a non-zero exit code.