### PR TITLE
shim: fix expansion for EFI_ARCH

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -34,7 +34,7 @@ SRC_URI = "\
 "
 SRC_URI:append:x86-64 = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'msft', \
-                         'file://shim' + d.expand('EFI_ARCH') + '.efi.signed file://LICENSE' \
+                         'file://shim' + d.expand('${EFI_ARCH}') + '.efi.signed file://LICENSE' \
                          if uks_signing_model(d) == 'sample' else '', '', d)} \
 "
 SRCREV = "5202f80c32bdcab0469785e953bf9fa8dd4eaaa1"


### PR DESCRIPTION
Fixes:
ERROR: shim_git.bb: Unable to get checksum for shim SRC_URI entry shimEFI_ARCH.efi.signed: file could not be found