### PR TITLE
ima-inspect: add missing stdint.h include

### DIFF
--- a/meta-integrity/recipes-support/ima-inspect/files/0001-ima_helpers-add-missing-stdint.h-include.patch
+++ b/meta-integrity/recipes-support/ima-inspect/files/0001-ima_helpers-add-missing-stdint.h-include.patch
@@ -1,0 +1,31 @@
+From 9a75001d7d20c56d65d4f197a7ec10aae26949c5 Mon Sep 17 00:00:00 2001
+From: Matthias Gerstner <matthias.gerstner@suse.de>
+Date: Tue, 28 Mar 2023 11:16:45 +0200
+Subject: [PATCH] ima_helpers: add missing stdint.h include
+
+On newer GCC versions this include is missing for uint8_t & friends.
+
+Upstream-Status: Backport [https://github.com/mgerstner/ima-inspect/commit/9a75001d7d20c56d65d4f197a7ec10aae26949c5]
+
+Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
+---
+ src/ima_helpers.hxx | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/ima_helpers.hxx b/src/ima_helpers.hxx
+index fdcae36..a7082e3 100644
+--- a/src/ima_helpers.hxx
++++ b/src/ima_helpers.hxx
+@@ -7,6 +7,9 @@
+ #ifndef IMA_HELPERS_HXX
+ #define IMA_HELPERS_HXX
+ 
++// C++
++#include <stdint.h>
++
+ // C++
+ #include <iosfwd>
+ 
+-- 
+2.25.1
+

--- a/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.13.bb
+++ b/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.13.bb
@@ -5,6 +5,7 @@ DEPENDS += "attr ima-evm-utils tclap"
 
 SRC_URI = " \
     git://github.com/mgerstner/ima-inspect.git;branch=master;protocol=https \
+    file://0001-ima_helpers-add-missing-stdint.h-include.patch \
 "
 SRCREV = "90f395c84eff54c69ba9ee078274313cfd308b53"
 


### PR DESCRIPTION
Backport patch [1] to fix the below build failure:
 | In file included from ../git/src/ima_helpers.cxx:12:
 | ../git/src/ima_helpers.hxx:17:27: error: 'uint8_t' does not name a type
 | 17 |         HexDumpData(const uint8_t *data, size_t bytes)

[1] https://github.com/mgerstner/ima-inspect/commit/9a75001d7d20c56d65d4f197a7ec10aae26949c5