### PR TITLE
efitools: Pass CFLAGS to make

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -27,6 +27,7 @@ SRC_URI = "\
     file://0013-Build-DBX-by-default.patch \
     file://0014-LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch \
     file://0015-fix-segfault-for-efitools-commands.patch \
+    file://0001-Make.rules-Pass-CFLAGS-to-Makefile.patch \
 "
 SRCREV = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
 
@@ -48,6 +49,7 @@ EXTRA_OEMAKE = "\
     NM='${NM}' AR='${AR}' \
     OPENSSL_LIB='${STAGING_LIBDIR_NATIVE}' \
     EXTRA_LDFLAGS='${LDFLAGS}' \
+    CFLAGS='${CFLAGS}' \
 "
 EXTRA_OEMAKE:append:x86 = " ARCH=ia32"
 EXTRA_OEMAKE:append:x86-64 = " ARCH=x86_64"

--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools/0001-Make.rules-Pass-CFLAGS-to-Makefile.patch
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools/0001-Make.rules-Pass-CFLAGS-to-Makefile.patch
@@ -1,0 +1,31 @@
+From 39f96d9b98a21618f4a36e5bb8d4bb6c4da6497f Mon Sep 17 00:00:00 2001
+From: Mingli Yu <mingli.yu@windriver.com>
+Date: Thu, 17 Aug 2023 15:11:25 +0800
+Subject: [PATCH] Make.rules: Pass CFLAGS to Makefile
+
+Make sure the right debug directory remapping options are passed to
+the compiler.
+
+Upstream-Status: Pending
+
+Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
+---
+ Make.rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Make.rules b/Make.rules
+index 0316ce5..1aa4465 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -15,7 +15,7 @@ $(error unknown architecture $(ARCH))
+ endif
+ INCDIR	   = -I$(TOPDIR)include/ -I$(INCDIR_PREFIX)/usr/include -I$(INCDIR_PREFIX)/usr/include/efi -I$(INCDIR_PREFIX)/usr/include/efi/$(ARCH) -I$(INCDIR_PREFIX)/usr/include/efi/protocol
+ cppflags   = -DCONFIG_$(ARCH) -D_GNU_SOURCE
+-cflags	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
++cflags	   = $(CFLAGS) -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
+ ldflags	   = -nostdlib
+ CRTOBJ		= crt0-efi-$(ARCH).o
+ CRTPATHS	= /lib /lib64 /lib/efi /lib64/efi /usr/lib /usr/lib64 /usr/lib/efi /usr/lib64/efi /usr/lib/gnuefi /usr/lib64/gnuefi
+-- 
+2.25.1
+


### PR DESCRIPTION
It ensures right debug directory remapping options are passed to compiler.

Fixes:
  WARNING: efitools-1.9.2-r0 do_package_qa: QA Issue: File /usr/bin/.debug/efi-updatevar in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/sig-list-to-certs in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/efi-readvar in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/hash-to-efi-sig-list in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/cert-to-efi-sig-list in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/sign-efi-sig-list in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/cert-to-efi-hash-list in package efitools-dbg contains reference to TMPDIR
  File /usr/bin/.debug/flash-var in package efitools-dbg contains reference to TMPDIR [buildpaths]