### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for nanbield

### DIFF
--- a/meta-efi-secure-boot/conf/layer.conf
+++ b/meta-efi-secure-boot/conf/layer.conf
@@ -19,4 +19,4 @@ LAYERDEPENDS_efi-secure-boot = "\
     perl-layer \
 "
 
-LAYERSERIES_COMPAT_efi-secure-boot = "mickledore"
+LAYERSERIES_COMPAT_efi-secure-boot = "nanbield"

--- a/meta-encrypted-storage/conf/layer.conf
+++ b/meta-encrypted-storage/conf/layer.conf
@@ -17,4 +17,4 @@ LAYERDEPENDS_encrypted-storage = "\
     openembedded-layer \
 "
 
-LAYERSERIES_COMPAT_encrypted-storage = "mickledore"
+LAYERSERIES_COMPAT_encrypted-storage = "nanbield"

--- a/meta-ids/conf/layer.conf
+++ b/meta-ids/conf/layer.conf
@@ -16,4 +16,4 @@ LAYERDEPENDS_ids = "\
     networking-layer \
 "
 
-LAYERSERIES_COMPAT_ids = "mickledore"
+LAYERSERIES_COMPAT_ids = "nanbield"

--- a/meta-integrity/conf/layer.conf
+++ b/meta-integrity/conf/layer.conf
@@ -27,4 +27,4 @@ BB_BASEHASH_IGNORE_VARS:append = " \
     RPM_FSK_PATH \
 "
 
-LAYERSERIES_COMPAT_integrity-layer = "mickledore"
+LAYERSERIES_COMPAT_integrity-layer = "nanbield"

--- a/meta-intel-sgx/conf/layer.conf
+++ b/meta-intel-sgx/conf/layer.conf
@@ -15,4 +15,4 @@ LAYERDEPENDS_intel-sgx = "\
     core \
 "
 
-LAYERSERIES_COMPAT_intel-sgx = "mickledore"
+LAYERSERIES_COMPAT_intel-sgx = "nanbield"

--- a/meta-signing-key/conf/layer.conf
+++ b/meta-signing-key/conf/layer.conf
@@ -13,7 +13,7 @@ BBLAYERS_LAYERINDEX_NAME_signing-key = "meta-signing-key"
 
 LAYERDEPENDS_signing-key = "core"
 
-LAYERSERIES_COMPAT_signing-key = "mickledore"
+LAYERSERIES_COMPAT_signing-key = "nanbield"
 
 SIGNING_MODEL ??= "sample"
 SAMPLE_MOK_SB_KEYS_DIR = "${LAYERDIR}/files/mok_sb_keys"

--- a/meta-tpm/conf/layer.conf
+++ b/meta-tpm/conf/layer.conf
@@ -13,4 +13,4 @@ BBLAYERS_LAYERINDEX_NAME_tpm = "meta-tpm"
 
 LAYERDEPENDS_tpm = "core"
 
-LAYERSERIES_COMPAT_tpm = "mickledore"
+LAYERSERIES_COMPAT_tpm = "nanbield"

--- a/meta-tpm2/conf/layer.conf
+++ b/meta-tpm2/conf/layer.conf
@@ -13,4 +13,4 @@ BBLAYERS_LAYERINDEX_NAME_tpm2 = "meta-tpm2"
 
 LAYERDEPENDS_tpm2 = "core"
 
-LAYERSERIES_COMPAT_tpm2 = "mickledore"
+LAYERSERIES_COMPAT_tpm2 = "nanbield"

--- a/meta/conf/layer.conf
+++ b/meta/conf/layer.conf
@@ -16,4 +16,4 @@ LAYERDEPENDS_secure-core = "\
     signing-key \
 "
 
-LAYERSERIES_COMPAT_secure-core = "mickledore"
+LAYERSERIES_COMPAT_secure-core = "nanbield"


### PR DESCRIPTION
oe-core has switched to nanbield in:
https://git.openembedded.org/openembedded-core/commit/?id=f212cb12a0db9c9de5afd3cc89b1331d386e55f6