### PR TITLE
Update GRUB2 SBAT global generation number to 4

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/sbat.csv
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/sbat.csv
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,3,Free Software Foundation,grub,@VERSION@,https://www.gnu.org/software/grub/
+grub,4,Free Software Foundation,grub,@VERSION@,https://www.gnu.org/software/grub/


### PR DESCRIPTION
Due to CVE-2023-4692 and CVE-2023-4693 GRUB2 vulnerabilities described at https://lists.gnu.org/archive/html/grub-devel/2023-10/msg00028.html, it's been agreed to update the required GRUB2 SBAT global generation number in its binaries to 4:
https://github.com/rhboot/shim-review/pull/348

This commit changes the aforementioned number from 3 to 4.