### PR TITLE
recipes: drop ${SRCPV} usage

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
@@ -27,7 +27,7 @@ SRC_URI = "git://github.com/jiazhang0/SELoader.git;branch=master;protocol=https 
           "
 
 SRCREV = "8b90f76a8df51d9020e67824026556434f407086"
-PV = "0.4.6+git${SRCPV}"
+PV = "0.4.6+git"
 
 S = "${WORKDIR}/git"
 

--- a/meta-efi-secure-boot/recipes-extended/mokutil/mokutil_git.bb
+++ b/meta-efi-secure-boot/recipes-extended/mokutil/mokutil_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS = "openssl efivar keyutils virtual/crypt"
 
-PV = "0.6.0+git${SRCPV}"
+PV = "0.6.0+git"
 
 SRC_URI = "git://github.com/lcp/mokutil.git;branch=master;protocol=https \
           "

--- a/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=89c8ce1346a3dfe75379e84f3ba9d641"
 
 DEPENDS = "tpm2-tss tpm2-abrmd pkgconfig-native"
 
-PV = "0.7.0+git${SRCPV}"
+PV = "0.7.0+git"
 
 SRC_URI = "\
     git://github.com/jiazhang0/cryptfs-tpm2.git;branch=master;protocol=https \

--- a/meta-ids/recipes-ids/mtree/mtree_git.bb
+++ b/meta-ids/recipes-ids/mtree/mtree_git.bb
@@ -6,7 +6,7 @@ SECTION = "utils"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bb19ea4eac951288efda4010c5c669a8"
 
-PV = "1.0.4+git${SRCPV}"
+PV = "1.0.4+git"
 
 SRC_URI = "git://github.com/archiecobbs/mtree-port.git;branch=master;protocol=https \
            file://mtree-getlogin.patch \

--- a/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
+++ b/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=d9bf404642f21afb4ad89f95d7bc91ee"
 
 DEPENDS += "openssl"
 
-PV = "0.3.2+git${SRCPV}"
+PV = "0.3.2+git"
 
 SRC_URI = "\
     git://github.com/jiazhang0/libsign.git;branch=master;protocol=https \

--- a/meta-signing-key/recipes-devtools/pesign/pesign_git.bb
+++ b/meta-signing-key/recipes-devtools/pesign/pesign_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/rhboot/pesign.git;protocol=https;name=sbsigntools;br
           "
 
 SRCREV = "227435af461f38fc4abeafe02884675ad4b1feb4"
-PV = "116+git${SRCPV}"
+PV = "116+git"
 
 COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
 

--- a/meta-tpm/recipes-tpm/pcr-extend/pcr-extend_git.bb
+++ b/meta-tpm/recipes-tpm/pcr-extend/pcr-extend_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS = "libtspi"
 
-PV = "0.1+git${SRCPV}"
+PV = "0.1+git"
 
 SRC_URI = "\
     git://github.com/flihp/pcr-extend.git;branch=master;protocol=https \

--- a/meta-tpm/recipes-tpm/tpm-quote-tools/tpm-quote-tools_git.bb
+++ b/meta-tpm/recipes-tpm/tpm-quote-tools/tpm-quote-tools_git.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=8ec30b01163d242ecf07d9cd84e3611f"
 
 DEPENDS = "libtspi tpm-tools"
 
-PV = "1.0.4+git${SRCPV}"
+PV = "1.0.4+git"
 
 SRC_URI = "\
     git://git.code.sf.net/p/tpmquotetools/tpm-quote-tools;branch=master \

--- a/meta-tpm/recipes-tpm/tss-testsuite/tss-testsuite_git.bb
+++ b/meta-tpm/recipes-tpm/tss-testsuite/tss-testsuite_git.bb
@@ -15,7 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=751419260aa954499f7abaabaa882bbe"
 
 DEPENDS = "trousers"
 
-PV = "git${SRCPV}"
+PV = "git"
 
 SRC_URI = "\
     git://git.code.sf.net/p/trousers/testsuite;branch=master \


### PR DESCRIPTION
Drop SRCPV as this variable is no longer needed in PV[1].

[1] https://git.openembedded.org/openembedded-core/commit/?id=a8e7b0f932b9ea69b3a218fca18041676c65aba0