### PR TITLE
meta-encrypted-storage: fix failure to find linux-yocto-luks.inc

### DIFF
--- a/meta-encrypted-storage/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-encrypted-storage/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -1,1 +1,1 @@
-include ${@bb.utils.contains('DISTRO_FEATURES', 'luks', '${BPN}-luks.inc', '', d)}
+include ${@bb.utils.contains('DISTRO_FEATURES', 'luks', 'linux-yocto-luks.inc', '', d)}

--- a/meta-encrypted-storage/recipes-kernel/linux/linux-yocto-rt_%.bbappend
+++ b/meta-encrypted-storage/recipes-kernel/linux/linux-yocto-rt_%.bbappend
@@ -1,1 +1,1 @@
-include ${@bb.utils.contains('DISTRO_FEATURES', 'luks', '${BPN}-luks.inc', '', d)}
+include ${@bb.utils.contains('DISTRO_FEATURES', 'luks', 'linux-yocto-luks.inc', '', d)}


### PR DESCRIPTION
linux-yocto-luks.inc is shared among linux-yocto, linux-yocto-rt and linux-yocto-dev and cannot be found with ${BPN} in the latter two.

ERROR: ParseError at layers/meta-secure-core/meta-encrypted-storage/recipes-kernel/linux/linux-yocto-dev.bbappend:1: Could not include required file linux-yocto-dev-luks.inc ERROR: ParseError at layers/meta-secure-core/meta-encrypted-storage/recipes-kernel/linux/linux-yocto-rt_%.bbappend:1: Could not include required file linux-yocto-rt-luks.inc