### PR TITLE
Fix conditions for vendor_dbx.esl in shim

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_15.8.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_15.8.bb
@@ -41,7 +41,7 @@ EXTRA_OEMAKE = "\
     ${@'VENDOR_CERT_FILE=${WORKDIR}/vendor_cert.cer' \
        if d.getVar('MOK_SB') == '1' else ''} \
     ${@'VENDOR_DBX_FILE=${WORKDIR}/vendor_dbx.esl' \
-       if uks_signing_model(d) == 'user' else ''} \
+       if d.getVar('MOK_SB') == '1' and uks_signing_model(d) == 'user' else ''} \
 "
 
 PARALLEL_MAKE = ""


### PR DESCRIPTION
vendor_dbx.esl is only built if SIGNING_MODEL=='user' and MOK_SB=='1', but it's inclusion in shim's EXTRA_OEMAKE is only guarded by SIGNING_MODEL.

Fixes #57 