### PR TITLE
tpm2-tss: drop libgcrypt dependency

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_4.1.3.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_4.1.3.bb
@@ -13,7 +13,7 @@ SRC_URI[sha256sum] = "37f1580200ab78305d1fc872d89241aaee0c93cbe85bc559bf332737a6
 
 UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
 
-DEPENDS = "libgcrypt openssl"
+DEPENDS = "openssl"
 
 inherit autotools pkgconfig systemd useradd
 
@@ -82,5 +82,3 @@ FILES:${PN} = " \
     ${sysconfdir}/tmpfiles.d \
     ${sysconfdir}/tpm2-tss \
     ${sysconfdir}/sysusers.d"
-
-RDEPENDS:libtss2 = "libgcrypt"


### PR DESCRIPTION
The libgcrypt ESYS crypto backend has been removed since 3.0.0[1]. Remove libgcrypt from DEPENDS and RDEPENDS.

[1] https://github.com/tpm2-software/tpm2-tss/releases/tag/3.0.0