### PR TITLE
shim: install shim.efi instead of boot.efi if MOK_SB=0

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -127,11 +127,11 @@ do_install() {
 
     local shim_dst="${D}${EFI_TARGET}/boot${EFI_ARCH}.efi"
     local mm_dst="${D}${EFI_TARGET}/mm${EFI_ARCH}.efi"
-    if [ x"${UEFI_SB}" = x"1" ]; then
+    if [ x"${UEFI_SB}" = x"1" -a x"${MOK_SB}" = x"1" ]; then
         install -m 0600 "${B}/shim${EFI_ARCH}.efi.signed" "$shim_dst"
         install -m 0600 "${B}/mm${EFI_ARCH}.efi.signed" "$mm_dst"
     else
-        install -m 0600 "${B}/shim${EFI_ARCH}.efi" "$shim_dst"
+        install -m 0600 "${B}/shim${EFI_ARCH}.efi" "${D}${EFI_TARGET}/shim${EFI_ARCH}.efi"
         install -m 0600 "${B}/mm${EFI_ARCH}.efi" "$mm_dst"
     fi
 }
@@ -145,7 +145,11 @@ do_deploy() {
     install -m 0600 "${B}/mm${EFI_ARCH}.efi" \
         "${DEPLOYDIR}/efi-unsigned/mm${EFI_ARCH}.efi"
 
-    install -m 0600 "${D}${EFI_TARGET}/boot${EFI_ARCH}.efi" "${DEPLOYDIR}"
+    if [ x"${UEFI_SB}" = x"1" -a x"${MOK_SB}" = x"1" ]; then
+        install -m 0600 "${D}${EFI_TARGET}/boot${EFI_ARCH}.efi" "${DEPLOYDIR}"
+    else
+        install -m 0600 "${D}${EFI_TARGET}/shim${EFI_ARCH}.efi" "${DEPLOYDIR}"
+    fi
     install -m 0600 "${D}${EFI_TARGET}/mm${EFI_ARCH}.efi" "${DEPLOYDIR}"
 }
 addtask deploy after do_install before do_build


### PR DESCRIPTION
There is a do_rootfs error in secure-core-image when UEFI_SB = 1 and MOK_SB = 0:
Error: Transaction test error:
  file /boot/efi/EFI/BOOT/bootx64.efi conflicts between attempted installs of seloader-0.4.6+git0+8b90f76a8d-r0.core2_64 and shim-15.8-r0.core2_64

When MOK_SB=0, SELoader will become the first stage loader and SELoader.efi will be renamed to bootx64.efi. This will conflict with bootx64.efi in shim.
To avoid this conflict, install shimx64.efi instead of bootx64.efi in shim if MOK_SB=0

Fixes: #64