### PR TITLE
Fixed shim build conditions

### DIFF
--- a/meta-efi-secure-boot/recipes-base/packagegroups/packagegroup-efi-secure-boot.bb
+++ b/meta-efi-secure-boot/recipes-base/packagegroups/packagegroup-efi-secure-boot.bb
@@ -8,6 +8,7 @@ S = "${WORKDIR}/sources"
 UNPACKDIR = "${S}"
 
 SELOADER_PKG = "${@'seloader' if d.getVar('UEFI_SELOADER') == '1' else ''}"
+SHIM_PKG = "${@'' if d.getVar('UEFI_SELOADER') == '1' and d.getVar('MOK_SB') != '1' else 'shim'}"
 ALLOW_EMPTY:${PN} = "1"
 
 pkgs = "\
@@ -16,7 +17,7 @@ pkgs = "\
     efibootmgr \
     mokutil \
     ${SELOADER_PKG} \
-    shim \
+    ${SHIM_PKG} \
 "
 
 RDEPENDS:${PN}:x86 = "${pkgs}"


### PR DESCRIPTION
If SELoader is built without MOK Secure boot enabled, shim and SELoader collide in deploying /EFI/BOOT/bootx64.efi:
```
Error: Transaction test error:
  file /boot/efi/EFI/BOOT/bootx64.efi conflicts between attempted installs of seloader-0.4.6+git0+8b90f76a8d-r0.corei7_64 and shim-12+git0+5202f80c32-r0.corei7_64
```

As shim is not needed without MOK Secure boot,
this patch disables it if the image is being built with SELoader but without MOK SB.

I can't fully test this patch right now, please run a test build before merging!
Fixes #64 
