### PR TITLE
ima-evm-rootfs.bbclass: remove references to mklibs and prelink

### DIFF
--- a/meta-integrity/classes/ima-evm-rootfs.bbclass
+++ b/meta-integrity/classes/ima-evm-rootfs.bbclass
@@ -59,9 +59,7 @@ ima_evm_sign_rootfs () {
 # Signing must run as late as possible in the do_rootfs task.
 # IMAGE_PREPROCESS_COMMAND runs after ROOTFS_POSTPROCESS_COMMAND, so
 # append (not prepend!) to IMAGE_PREPROCESS_COMMAND, and do it with
-# :append instead of += because :append gets evaluated later. In
-# particular, we must run after prelink_image in
-# IMAGE_PREPROCESS_COMMAND, because prelinking changes executables.
+# :append instead of += because :append gets evaluated later.
 
 IMAGE_PREPROCESS_COMMAND:append = " ima_evm_sign_rootfs;"
 
@@ -71,9 +69,3 @@ do_rootfs[depends] += "ima-evm-utils-native:do_populate_sysroot"
 IMAGE_CMD_TAR = "tar --xattrs --xattrs-include=*"
 do_image_tar[depends] += "tar-replacement-native:do_populate_sysroot"
 EXTRANATIVEPATH += "tar-native"
-
-
-#USER_CLASSES:remove = " image-mklibs image-prelink"
-IMAGE_PREPROCESS_COMMAND:remove = " mklibs_optimize_image;"
-IMAGE_PREPROCESS_COMMAND:remove = " prelink_setup;"
-IMAGE_PREPROCESS_COMMAND:remove = " prelink_image;"


### PR DESCRIPTION
The image-mklibs.bbclass and image-prelink.bbclass have been removed in commits[1][2].

[1] https://git.openembedded.org/openembedded-core/commit/?id=908df863b419d1cad7317153101fc827e7e3a354
[2] https://git.openembedded.org/openembedded-core/commit/?id=857baaf9e3d181ca18264e85d90b899fd94acff9