### PR TITLE
Add gen-sbkeys.bb recipe

### DIFF
--- a/meta-signing-key/recipes-devtools/gen-sbkeys/gen-sbkeys.bb
+++ b/meta-signing-key/recipes-devtools/gen-sbkeys/gen-sbkeys.bb
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+
+SUMMARY = "Generate Signing UEFI keys for Secure Boot"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+DEPENDS = "bash-native coreutils-native efitools-native openssl-native"
+
+SRC_URI = "file://gen_sbkeys.sh"
+
+UNPACKDIR = "${S}"
+
+do_patch[noexec] = "1"
+do_compile[noexec] = "1"
+do_configure[noexec] = "1"
+do_install[nostamp] = "1"
+
+python do_install() {
+    keys_dir = d.getVar('SBSIGN_KEYS_DIR')
+    if not keys_dir:
+        bb.warn("SBSIGN_KEYS_DIR is not set. Skipping generating keys...")
+        return
+
+    keys_to_check = [
+        keys_dir + "/PK.esl",
+        keys_dir + "/KEK.esl",
+        keys_dir + "/db.esl",
+        keys_dir + "/dbx.esl",
+        keys_dir + "/db.key",
+        keys_dir + "/db.crt",
+    ]
+
+    missing_keys = [f for f in keys_to_check if not os.path.exists(f)]
+
+    if not missing_keys:
+        bb.debug(2, "All UEFI keys found in '%s' to sign binaries'" % keys_dir)
+        return
+
+    gen_sbkeys = d.getVar('UNPACKDIR') + "/gen_sbkeys.sh"
+
+    import subprocess
+    bb.debug(2, "Calling '%s' to generate UEFI keys in path: '%s'" % (gen_sbkeys, keys_dir))
+    cmd = "%s %s" % (gen_sbkeys, keys_dir)
+    subprocess.Popen(cmd, shell=True)
+}
+
+FILES:${PN} += "${SBSIGN_KEYS_DIR}/db.key"
+FILES:${PN} += "${SBSIGN_KEYS_DIR}/db.crt"

--- a/meta-signing-key/recipes-devtools/gen-sbkeys/gen-sbkeys/gen_sbkeys.sh
+++ b/meta-signing-key/recipes-devtools/gen-sbkeys/gen-sbkeys/gen_sbkeys.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: MIT
+#
+#
+# Set up UEFI Secure Boot keys. Generate keys and certificates, convert them
+# into EFI Signature Lists, and sign them. By managing these keys, you can
+# control what is considered trusted on your system.
+
+set -eux
+
+KEYS_PATH=${1:-./}
+SUBJECT="/CN=OpenEmbedded/"
+
+# The number used is just a GUID random number that has not special meaning.
+# GUID (Globally Unique Identifier) is associated with the signature list. GUIDs
+# in this context are used to uniquely identify the owner or the purpose of the
+# keys within the EFI environment. This GUID can be used to distinguish
+# different lists or purposes within the UEFI firmware settings
+GUID="11111111-2222-3333-4444-123456789abc"
+
+if [ ! -d "${KEYS_PATH}" ]; then
+    mkdir -p "${KEYS_PATH}"
+fi
+
+if [ -f "${KEYS_PATH}"/PK.crt ]; then
+    exit 0
+fi
+
+# Platform Key (PK): The root key in Secure Boot, which authorizes changes to
+# the KEK
+openssl req -x509 -sha256 -newkey rsa:2048 -subj "${SUBJECT}" \
+    -keyout "${KEYS_PATH}"/PK.key -out "${KEYS_PATH}"/PK.crt \
+    -nodes -days 3650
+cert-to-efi-sig-list -g ${GUID} \
+    "${KEYS_PATH}"/PK.crt "${KEYS_PATH}"/PK.esl
+sign-efi-sig-list -c "${KEYS_PATH}"/PK.crt -k "${KEYS_PATH}"/PK.key \
+    "${KEYS_PATH}"/PK "${KEYS_PATH}"/PK.esl "${KEYS_PATH}"/PK.auth
+
+# Key Exchange Key (KEK): Allows for updates to the db and dbx lists
+#
+# db and dbx: Control lists for allowed and disallowed executable files and
+# drivers
+for key in KEK db dbx; do
+    openssl req -x509 -sha256 -newkey rsa:2048 -subj "${SUBJECT}" \
+        -keyout "${KEYS_PATH}"/${key}.key -out "${KEYS_PATH}"/${key}.crt \
+        -nodes -days 3650
+    cert-to-efi-sig-list -g ${GUID} \
+        "${KEYS_PATH}"/${key}.crt "${KEYS_PATH}"/${key}.esl
+    sign-efi-sig-list -c "${KEYS_PATH}"/PK.crt -k "${KEYS_PATH}"/PK.key \
+        "${KEYS_PATH}"/${key} "${KEYS_PATH}"/${key}.esl "${KEYS_PATH}"/${key}.auth
+done


### PR DESCRIPTION
Generate keys that can be used to sign EFI binaries.

The keys will be stored in the SBSIGN_KEYS_DIR directory, and if they are already there, new keys will not be generated to keep build reproducibility.

Originally, this change was submitted to meta-arm to enable Secure Boot, but as it's using efitools, it's more appropriate to add it to meta-secure-core.