### PR TITLE
efitools: improve the native build

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools-native_1.9.2.bb
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools-native_1.9.2.bb
@@ -2,9 +2,15 @@ require efitools.inc
 
 inherit native
 
-DEPENDS:append = " gnu-efi-native"
-
 EXTRA_OEMAKE:append = " \
     INCDIR_PREFIX='${STAGING_DIR_NATIVE}' \
     CRTPATH_PREFIX='${STAGING_DIR_NATIVE}' \
 "
+
+do_compile() {
+    oe_runmake binaries
+}
+
+do_install() {
+    oe_runmake install-binaries DESTDIR='${D}${base_prefix}'
+}

--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -10,26 +10,26 @@ in the Linux 3.8 kernel. \
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e28f66b16cb46be47b20a4cdfe6e99a1"
 
-SRC_URI = "\
-    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;branch=master \
-    file://0001-Fix-for-the-cross-compilation.patch \
-    file://0002-Make.rules-define-_GNU_SOURCE-for-a-declaration-of-f.patch \
-    file://0003-Fix-the-wrong-dependency-for-blacklist.esl.patch \
-    file://0004-LockDown-run-system-warm-reset-after-the-key-provisi.patch \
-    file://0005-Allow-to-override-tools-for-target-build.patch \
-    file://0006-Makefile-remove-help2man-dependency.patch \
-    file://0007-Add-static-keyword-for-IsValidVariableHeader.patch \
-    file://0008-Dynamically-load-openssl.cnf-for-openssl-1.0.x-1.1.x.patch \
-    file://0009-console.c-Fix-compilation-against-latest-usr-include.patch \
-    file://0010-LockDown-enable-the-enrollment-for-DBX.patch \
-    file://0011-LockDown-show-the-error-message-with-3-sec-timeout.patch \
-    file://0012-Makefile-do-not-build-signed-efi-image.patch \
-    file://0013-Build-DBX-by-default.patch \
-    file://0014-LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch \
-    file://0015-fix-segfault-for-efitools-commands.patch \
-    file://0016-Make.rules-Pass-CFLAGS-to-Makefile.patch \
-    file://0017-Make.rules-fix-efi-files-for-gnu-efi-3.0.18.patch \
-"
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;branch=master \
+           file://0001-Fix-for-the-cross-compilation.patch \
+           file://0002-Make.rules-define-_GNU_SOURCE-for-a-declaration-of-f.patch \
+           file://0003-Fix-the-wrong-dependency-for-blacklist.esl.patch \
+           file://0004-LockDown-run-system-warm-reset-after-the-key-provisi.patch \
+           file://0005-Allow-to-override-tools-for-target-build.patch \
+           file://0006-Makefile-remove-help2man-dependency.patch \
+           file://0007-Add-static-keyword-for-IsValidVariableHeader.patch \
+           file://0008-Dynamically-load-openssl.cnf-for-openssl-1.0.x-1.1.x.patch \
+           file://0009-console.c-Fix-compilation-against-latest-usr-include.patch \
+           file://0010-LockDown-enable-the-enrollment-for-DBX.patch \
+           file://0011-LockDown-show-the-error-message-with-3-sec-timeout.patch \
+           file://0012-Makefile-do-not-build-signed-efi-image.patch \
+           file://0013-Build-DBX-by-default.patch \
+           file://0014-LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch \
+           file://0015-fix-segfault-for-efitools-commands.patch \
+           file://0016-Make.rules-Pass-CFLAGS-to-Makefile.patch \
+           file://0017-Make.rules-fix-efi-files-for-gnu-efi-3.0.18.patch \
+           file://0001-add-binary-only-make-rules.patch \
+           "
 SRCREV = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
 
 DEPENDS = "openssl-native sbsigntool-native \

--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools/0001-add-binary-only-make-rules.patch
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools/0001-add-binary-only-make-rules.patch
@@ -1,0 +1,39 @@
+From 77ce20597eb0283f1a089c0cf4923346338bde8b Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@arm.com>
+Date: Wed, 27 Nov 2024 17:15:33 +0000
+Subject: [PATCH] add binary-only make rules
+
+Add rules to build and install just the binaries, for the native recipe.
+
+Upstream-Status: Pending
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+---
+ Makefile | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 66f5d2e..e42de67 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,15 +29,18 @@ EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
+ all: $(EFIFILES) $(BINARIES) noPK.auth $(KEYAUTH) DBX.auth \
+ 	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
+ 
++binaries: $(BINARIES)
+ 
+-install: all
++install: all install-binaries
+ 	$(INSTALL) -m 755 -d $(EFIDIR)
+ 	$(INSTALL) -m 755 $(EFIFILES) $(EFIDIR)
++	$(INSTALL) -m 755 -d $(DOCDIR)
++	$(INSTALL) -m 644 README COPYING $(DOCDIR)
++
++install-binaries: binaries
+ 	$(INSTALL) -m 755 -d $(BINDIR)
+ 	$(INSTALL) -m 755 $(BINARIES) $(BINDIR)
+ 	$(INSTALL) -m 755 mkusb.sh $(BINDIR)/efitool-mkusb
+-	$(INSTALL) -m 755 -d $(DOCDIR)
+-	$(INSTALL) -m 644 README COPYING $(DOCDIR)
+ 
+ lib/lib.a lib/lib-efi.a: FORCE
+ 	$(MAKE) -C lib $(notdir $@)


### PR DESCRIPTION
The native build of efitools is only needed for the tools, add a patch so that we can just build and install the tools.

This means we don't need to depend on gnu-efi-native anymore, and also the native recipe doesn't end up shipping a build-host-targetting LockDown.efi in the sysroot which is obviously incorrect.

(note that I've not tested this on hardware, but the build appears to work)