### PR TITLE
linux-yocto-efi-secure-boot.inc: fix missing prefuncs

### DIFF
--- a/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
@@ -80,6 +80,8 @@ fakeroot python do_sign_bundled_kernel() {
         shutil.copyfile(kernel + ext, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin' + ext))
 }
 addtask sign_bundled_kernel after do_bundle_initramfs before do_deploy
+do_sign_bundled_kernel[prefuncs] += "check_deploy_keys"
+do_sign_bundled_kernel[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
 
 do_deploy:append() {
     install -d "${DEPLOYDIR}/efi-unsigned"


### PR DESCRIPTION
There is a do_sign_bundled_kernel in kernel build when UEFI_SELOADER = 0 and GRUB_SIGN_VERIFY = 1:
Error: Failed to sign error:
  file /boot/bzImage.initramfs fails to be signed within do_sign_bundled_kernel function

When do_sign_bundled_kernel is called there is no access to deployed keys within boot_sign as gpg_path is empty, thus check_deploy_keys and check_boot_public_key are being added into do_sign_bundled_kernel[prefuncs]

Fixes: #85