### PR TITLE
README: do not inherit sign_rpm_ext class for ima feature

### DIFF
--- a/README
+++ b/README
@@ -81,7 +81,7 @@ DISTRO_FEATURES:append = " ima tpm2 efi-secure-boot luks modsign"
 MACHINE_FEATURES_NATIVE:append = " efi"
 MACHINE_FEATURES:append = " efi"
 PACKAGE_CLASSES = "package_rpm"
-INHERIT += "sign_rpm_ext ima-evm-rootfs"
+INHERIT += "ima-evm-rootfs"
 SECURE_CORE_IMAGE_EXTRA_INSTALL ?= "\
     packagegroup-efi-secure-boot \
     packagegroup-tpm2 \


### PR DESCRIPTION
After rpm was updated to 4.20, rpm signing support has been disabled by default in oe-core[1]. This is because the internal openpgp parser was removed in rpm 4.20, and its replacement rpm-sequoia[2] requires clang and rust. The oe-core can't force both rust and clang into the default build dependency chain[3].

For feature ima, we skip signing the files in rpm package by not inheriting sign_rpm_ext class and sign all files during do_image via ima-evm-rootfs class.

[1] https://git.openembedded.org/openembedded-core/commit/?id=8c15b4577d5e554cc2dd5adfb88b816894b05a9a
[2] https://github.com/rpm-software-management/rpm-sequoia/
[3] https://lists.openembedded.org/g/openembedded-architecture/topic/102780086