### PR TITLE
user-key-store: do not preserve key file ownership when deploying

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -335,7 +335,7 @@ deploy_uefi_sb_keys() {
     if [ x"${UEFI_SB_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${UEFI_SB_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${UEFI_SB_KEYS_DIR}"/* "$deploy_dir"
         for KEY in DB KEK PK; do
              openssl x509 -in "${UEFI_SB_KEYS_DIR}"/${KEY}.crt \
                  -out "$deploy_dir"/${KEY}.cer -outform DER;
@@ -349,7 +349,7 @@ deploy_mok_sb_keys() {
     if [ x"${MOK_SB_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${MOK_SB_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${MOK_SB_KEYS_DIR}"/* "$deploy_dir"
     fi
 }
 
@@ -359,7 +359,7 @@ deploy_ima_keys() {
     if [ x"${IMA_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${IMA_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${IMA_KEYS_DIR}"/* "$deploy_dir"
     fi
 }
 
@@ -369,7 +369,7 @@ deploy_rpm_keys() {
     if [ x"${RPM_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${RPM_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${RPM_KEYS_DIR}"/* "$deploy_dir"
     fi
 }
 
@@ -379,7 +379,7 @@ deploy_system_trusted_keys() {
     if [ x"${SYSTEM_TRUSTED_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${SYSTEM_TRUSTED_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${SYSTEM_TRUSTED_KEYS_DIR}"/* "$deploy_dir"
     fi
 }
 
@@ -389,7 +389,7 @@ deploy_secondary_trusted_keys() {
     if [ x"${SECONDARY_TRUSTED_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${SECONDARY_TRUSTED_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${SECONDARY_TRUSTED_KEYS_DIR}"/* "$deploy_dir"
     fi
 }
 
@@ -399,7 +399,7 @@ deploy_modsign_keys() {
     if [ x"${MODSIGN_KEYS_DIR}" != x"$deploy_dir" ]; then
         install -d "$deploy_dir"
 
-        cp -af "${MODSIGN_KEYS_DIR}"/* "$deploy_dir"
+        cp --preserve=mode -rf "${MODSIGN_KEYS_DIR}"/* "$deploy_dir"
     fi
 }
 


### PR DESCRIPTION
Got this error while building on my CI system (using docker and debian 12.8):

    ERROR: linux-6.1.68+git-r0 do_sign: ExecutionError('/builds/.../tmp/work/linux/6.1.68+git/temp/run.deploy_uefi_sb_keys.903779', 1, None, None)
    ERROR: Logfile of failure stored in: /builds/.../tmp/work/machine-eko-linux/linux/6.1.68+git/temp/log.do_sign.903779
    | DEBUG: Executing python function check_deploy_keys
    | DEBUG: Executing shell function deploy_uefi_sb_keys
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/DB.crt': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/DB.key': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/DBX/DBX.crt': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/DBX/DBX.key': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/DBX': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/KEK.crt': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/KEK.key': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/PK.crt': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/PK.key': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/ms-DB.crt': Invalid argument
    | cp: failed to preserve ownership for '/builds/.../tmp/deploy/images/machine/sample-keys/uefi_sb_keys/ms-KEK.crt': Invalid argument
    | WARNING: exit code 1 from a shell command.
    | DEBUG: Python function check_deploy_keys finished
    Log data follows:
    NOTE: recipe linux-6.1.68+git-r0: task do_sign: Failed
    ERROR: Task (/builds/meta-layer/common/recipes-kernel/linux/linux.bb:do_sign) failed with exit code '1'

The build works fine on my desktop (not using docker in this case) so my guess is that the files are created with a user specific to the docker image and then trying to preserve the ownership fails when deploying (not 100% sure).

Using 'cp --preserve=mode -rf' instead of 'cp -af' will do a recursive copy _but_ will only preserve the mode (using the '-a' option preserves all atttributes) making the file copy operation successfull even in cases where the file ownership could not be preserved.