### PR TITLE
rpm: enable sequoia packageconfig for ima feature

### DIFF
--- a/README
+++ b/README
@@ -81,7 +81,7 @@ DISTRO_FEATURES:append = " ima tpm2 efi-secure-boot luks modsign"
 MACHINE_FEATURES_NATIVE:append = " efi"
 MACHINE_FEATURES:append = " efi"
 PACKAGE_CLASSES = "package_rpm"
-INHERIT += "ima-evm-rootfs"
+INHERIT += "sign_rpm_ext ima-evm-rootfs"
 SECURE_CORE_IMAGE_EXTRA_INSTALL ?= "\
     packagegroup-efi-secure-boot \
     packagegroup-tpm2 \

--- a/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
+++ b/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/rpm:"
 
 PACKAGECONFIG:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'imaevm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'sequoia', '', d)} \
     "
 
 # IMA signing support is provided by RPM plugin.


### PR DESCRIPTION
Since rpm-sequoia was added to oe-core[1], rpm signing support has been restored. So we can re-inherit sign_rpm_ext class in ima feautre.

[1] https://git.openembedded.org/openembedded-core/commit/?id=d8b01b436d37f4deb2de5d234e8f04c957719ca3