### PR TITLE
tpm2-openssl: upgrade 1.2.0 -> 1.3.0

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-openssl/tpm2-openssl_1.3.0.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-openssl/tpm2-openssl_1.3.0.bb
@@ -6,11 +6,11 @@ HOMEPAGE = "https://github.com/tpm2-software/tpm2-openssl"
 SECTION = "tpm"
 
 LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=b75785ac083d3c3ca04d99d9e4e1fbab"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3f4b4cb00f4d0d6807a0dc79759a57ac"
 
 SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz"
 
-SRC_URI[sha256sum] = "2ee15da2dceae1466ffba868e75a00b119d752babc1b6a2792286336a3324fb0"
+SRC_URI[sha256sum] = "9a9aca55d4265ec501bcf9c56d21d6ca18dba902553f21c888fe725b42ea9964"
 
 UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
 


### PR DESCRIPTION
ChangeLog:
https://github.com/tpm2-software/tpm2-openssl/releases/tag/1.3.0

License-Update: Updated copyright years