### PR TITLE
gen-sbkeys: add source code location

### DIFF
--- a/meta-signing-key/recipes-devtools/gen-sbkeys/gen-sbkeys.bb
+++ b/meta-signing-key/recipes-devtools/gen-sbkeys/gen-sbkeys.bb
@@ -8,6 +8,8 @@ DEPENDS = "bash-native coreutils-native efitools-native openssl-native"
 
 SRC_URI = "file://gen_sbkeys.sh"
 
+S = "${UNPACKDIR}"
+
 do_patch[noexec] = "1"
 do_compile[noexec] = "1"
 do_configure[noexec] = "1"


### PR DESCRIPTION
Currently seeing the following warning:
WARNING: gen-sbkeys-1.0-r0 do_unpack: gen-sbkeys: the directory ${UNPACKDIR}/${BP} pointed to by the S variable doesn't exist - please set S within the recipe to point to where the source has been unpacked to

Set S to the UNPACKDIR to address this issue