### PR TITLE
ima-evm-utils: disable manpage build

### DIFF
--- a/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils_1.5.bb
+++ b/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils_1.5.bb
@@ -19,6 +19,7 @@ DEPENDS = "openssl attr keyutils"
 inherit pkgconfig autotools
 
 EXTRA_OECONF = "--with-kernel-headers=${STAGING_KERNEL_DIR}"
+EXTRA_OECONF += "MANPAGE_DOCBOOK_XSL=0"
 
 do_compile:append() {
     # Remove build host references


### PR DESCRIPTION
Forcibly disable manpage build.
Since external tools are required to build the man pages, we don't need them anyway.