### PR TITLE
shim: Fix CVE-2023-40551

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim/CVE-2023-40551.patch
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim/CVE-2023-40551.patch
@@ -1,0 +1,87 @@
+From 5a5147d1e19cf90ec280990c84061ac3f67ea1ab Mon Sep 17 00:00:00 2001
+From: Peter Jones <pjones@redhat.com>
+Date: Wed, 26 Jul 2023 14:47:45 -0400
+Subject: [PATCH] CVE-2023-40551: pe-relocate: Fix bounds check for MZ binaries
+
+In read_header(), we attempt to parse the PE binary headers.  In doing
+so, if there is an MZ (i.e. MS-DOS) header, we locate the PE header by
+finding the offset in that header.  Unfortunately that is not correctly
+bounds checked, and carefully chosen values can cause an out-of-bounds
+ready beyond the end of the loaded binary.
+
+Unfortunately the trivial fix (bounds check that value) also makes it
+clear that the way we were determining if an image is loadable on this
+platform and distinguishing between PE32 and PE32+ binaries has the
+exact same issue going on, and so the fix includes reworking that logic
+to correctly bounds check all of those tests as well.
+
+It's not currently known if this is actually exploitable beyond creating
+a denial of service, and an attacker who is in a position to use it for
+a denial of service attack must already be able to do so.
+
+Resolves: CVE-2023-40551
+Reported-by: gkirkpatrick@google.com
+Signed-off-by: Peter Jones <pjones@redhat.com>
+
+CVE: CVE-2023-40551
+
+Upstream-Status: Backport [https://github.com/rhboot/shim/commit/5a5147d1e19cf90ec280990c84061ac3f67ea1ab]
+
+Signed-off-by: Soumya Sambu <soumya.sambu@windriver.com>
+---
+ shim.c | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/shim.c b/shim.c
+index 08aa580..4cd5dc2 100644
+--- a/shim.c
++++ b/shim.c
+@@ -176,7 +176,7 @@ static int
+ image_is_64_bit(EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr)
+ {
+ 	/* .Magic is the same offset in all cases */
+-	if (PEHdr->Pe32Plus.OptionalHeader.Magic
++	if (PEHdr->Pe32.OptionalHeader.Magic
+ 			== EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC)
+ 		return 1;
+ 	return 0;
+@@ -1074,14 +1074,34 @@ static EFI_STATUS read_header(void *data, unsigned int datasize,
+ 	EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr = data;
+ 	unsigned long HeaderWithoutDataDir, SectionHeaderOffset, OptHeaderSize;
+ 	unsigned long FileAlignment = 0;
++	size_t dos_sz = 0;
+ 
+-	if (datasize < sizeof (PEHdr->Pe32)) {
++	if (datasize < sizeof (*DosHdr)) {
+ 		perror(L"Invalid image\n");
+ 		return EFI_UNSUPPORTED;
+ 	}
+ 
+-	if (DosHdr->e_magic == EFI_IMAGE_DOS_SIGNATURE)
++	if (DosHdr->e_magic == EFI_IMAGE_DOS_SIGNATURE) {
++		if (DosHdr->e_lfanew < sizeof (*DosHdr) ||
++		    DosHdr->e_lfanew > datasize - 4) {
++			perror(L"Invalid image\n");
++			return EFI_UNSUPPORTED;
++		}
++
++		dos_sz = DosHdr->e_lfanew;
+ 		PEHdr = (EFI_IMAGE_OPTIONAL_HEADER_UNION *)((char *)data + DosHdr->e_lfanew);
++	}
++
++	if (datasize - dos_sz < sizeof (PEHdr->Pe32)) {
++		perror(L"Invalid image\n");
++		return EFI_UNSUPPORTED;
++	}
++
++	if (image_is_64_bit(PEHdr) &&
++	    (datasize - dos_sz < sizeof (PEHdr->Pe32Plus))) {
++		perror(L"Invalid image\n");
++		return EFI_UNSUPPORTED;
++	}
+ 
+ 	if (!image_is_loadable(PEHdr)) {
+ 		perror(L"Platform does not support this image\n");
+-- 
+2.40.0
+

--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -32,6 +32,7 @@ SRC_URI = "\
     file://CVE-2022-28737-0001.patch \
     file://CVE-2022-28737-0002.patch \
     file://CVE-2023-40547.patch \
+    file://CVE-2023-40551.patch \
 "
 SRC_URI:append:x86-64 = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'msft', \


### PR DESCRIPTION
A flaw was found in the MZ binary format in Shim. An out-of-bounds read may occur, leading to a crash or possible exposure of sensitive data during the system's boot phase.

References:
https://nvd.nist.gov/vuln/detail/CVE-2023-40551
https://ubuntu.com/security/CVE-2023-40551

Upstream patch:
https://github.com/rhboot/shim/commit/5a5147d1e19cf90ec280990c84061ac3f67ea1ab