### PR TITLE
seloader: align .sbat section to page boundary to avoid shim warning

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
@@ -55,9 +55,27 @@ python do_sign() {
 addtask sign after do_compile before do_install
 do_sign[prefuncs] += "check_deploy_keys"
 
+# By default, use a VMA and LMA address of 0x20000, this puts the
+# .sbat section at the end of the SELoaderx64.efi binary and at a page
+# boundary (multiple of 4096).
+SELOADER_SBAT_VMA ?= "0x20000"
+
 do_compile:append() {
     # Add .sbat section
-    ${OBJCOPY} --set-section-alignment '.sbat=512' --add-section .sbat=${UNPACKDIR}/sbat.csv --adjust-section-vma .sbat+10000000 ${B}/Src/Efi/SELoader.efi
+    #
+    # --remove-section is used to make sure that if the compile task
+    # is re-executed (possibly with different arguments) it will still
+    # work and not give a "file in wrong format" error.
+    #
+    # Ref.:
+    # - https://www.rodsbooks.com/efi-bootloaders/secureboot.html#sbat
+    # - https://github.com/rhboot/shim/blob/main/SBAT.md#how-to-add-sbat-sections
+
+    ${OBJCOPY} --set-section-alignment '.sbat=512' \
+               --remove-section .sbat \
+               --add-section .sbat=${UNPACKDIR}/sbat.csv \
+               --adjust-section-vma .sbat+${SELOADER_SBAT_VMA} \
+               ${B}/Src/Efi/SELoader.efi
 }
 
 do_install() {


### PR DESCRIPTION
When launching SELoader via shim (tested with 16.1), the following warning is consistently printed:

```
    Invalid call dxe_update_mem_attrs(addr:0xE9004680-0xE900567F, size:0x1000, +r, -wx)
     addr is not page aligned
```

This does not prevent the system from booting, but indicates that shim is attempting to apply memory attributes on a region that is not page-aligned.

Inspection of the generated SELoaderx64.efi shows that the .sbat section is the only section whose VMA/LMA is not aligned to a 4 KiB page boundary:

```
Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .eh_frame     0000278c  0000000000001000  0000000000001000  00000400  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  1 .text         0000bc10  0000000000004000  0000000000004000  00002c00  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .data         00000f28  0000000000010000  0000000000010000  0000ea00  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  3 .reloc        0000000c  0000000000011000  0000000000011000  0000fa00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  4 .dynamic      00000110  0000000000012000  0000000000012000  0000fc00  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  5 .rela         00000f78  0000000000013000  0000000000013000  0000fe00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  6 .rodata       000049f6  0000000000014000  0000000000014000  00010e00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  7 .sbat         00000096  0000000000989680  0000000000989680  00015800  2**2  <----- !!!!!!!!!!!!!!!
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
```

Section 7 (sbat), is the only section which is not aligned on a page boundary address (0x989680 == 1000000). From what I understand, this VMA address comes from a suggestion in the shim bug tracker [1].

Fix this by placing the .sbat section at a page-aligned address using a configurable offset (SELOADER_SBAT_VMA, default: 0x20000). This keeps the section at the end of the binary while ensuring proper alignment:

```
Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .eh_frame     0000278c  0000000000001000  0000000000001000  00000400  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  1 .text         0000bc10  0000000000004000  0000000000004000  00002c00  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .data         00000f28  0000000000010000  0000000000010000  0000ea00  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  3 .reloc        0000000c  0000000000011000  0000000000011000  0000fa00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  4 .dynamic      00000110  0000000000012000  0000000000012000  0000fc00  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  5 .rela         00000f78  0000000000013000  0000000000013000  0000fe00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  6 .rodata       000049f6  0000000000014000  0000000000014000  00010e00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  7 .sbat         00000096  0000000000020000  0000000000020000  00015800  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
```

With this change, the warning is no longer emitted during boot.

Additionally, use --remove-section .sbat before re-adding it to ensure the build remains reproducible when do_compile is re-executed, avoiding "file in wrong format" errors from objcopy.

1: https://github.com/rhboot/shim/issues/376