### PR TITLE
grub-efi bbappend: update search parameter

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -86,18 +86,8 @@ EOF
     else
         > ${WORKDIR}/cfg
     fi
-
-    if [ "${GRUB_SIGN_VERIFY}" = "0" -a "${UEFI_SELOADER}" = "1" ] ; then
-        cat<<EOF>>${WORKDIR}/cfg
-search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
-EOF
-    else
-        cat<<EOF>>${WORKDIR}/cfg
-search.file ${GRUB_PREFIX_DIR}/grub.cfg root
-EOF
-    fi
-
     cat<<EOF>>${WORKDIR}/cfg
+search --file --set=root --hint-efi=(\$cmdpath) ${GRUB_PREFIX_DIR}/EFI/BOOT/grub.cfg
 set prefix=(\$root)${GRUB_PREFIX_DIR}
 EOF
 


### PR DESCRIPTION
grub would report an error message in boot stage as below:

   "error: no such device: ((hd0,gpt1)/EFI/BOOT)/EFI/BOOT/grub.cfg"

Consequently, the root variable is not set, and the intended protection against cross-device configuration loading (the purpose of the original 2014 commit) is lost.

The most robust fix is to use the --hint parameter. This separates the search target from the device hint, avoiding fragile string concatenation and supporting both prefixed and non-prefixed $cmdpath formats.

The modification line up with openembedded-core.git commit:42b530581f724 ("grub: update search parameter")