### PR TITLE
layer.conf: enable GRUB_SIGN_VERIFY by default instead of UEFI_SELOADER

### DIFF
--- a/README
+++ b/README
@@ -91,10 +91,10 @@ SECURE_CORE_IMAGE_EXTRA_INSTALL ?= "\
 #DEBUG_FLAGS:forcevariable = ""
 IMAGE_INSTALL:append = " kernel-image-bzimage"
 
-# Uncomment the following lines to disable SELoader
-# and use gpg key to protect and verify files used by grub.
-#UEFI_SELOADER ?= "0"
-#GRUB_SIGN_VERIFY ?= "1"
+# By default, a GPG key is used to protect and verify the files used by GRUB.
+# Uncomment the following line to enable SELoader.
+#UEFI_SELOADER ?= "1"
+#GRUB_SIGN_VERIFY ?= "0"
 
 # Uncomment this line to modify the root parameter in boot command line if the default one
 # is not working for you. It is helpful when secure boot is enabled.

--- a/meta-signing-key/conf/layer.conf
+++ b/meta-signing-key/conf/layer.conf
@@ -35,10 +35,10 @@ MSFT_KEK_CERT = "${LAYERDIR}/files/uefi_sb_keys/ms-KEK.crt"
 EV_CERT ??= "${LAYERDIR}/files/mok_sb_keys/wosign_ev_cert.crt"
 
 # Use SELoader with the UEFI shim
-UEFI_SELOADER ??= "1"
+UEFI_SELOADER ??= "0"
 
 # Use gpg key to protect and verify all files used by grub
-GRUB_SIGN_VERIFY ??= "0"
+GRUB_SIGN_VERIFY ??= "1"
 
 # Signing file extension
 SB_FILE_EXT = "${@'.p7b' if d.getVar('UEFI_SELOADER') == "1" else '.sig'}"


### PR DESCRIPTION
With the updates of shim to 16.1 and GRUB to 2.14, SELoader faces two issues:

1. Shim 16.1 implements its own LoadImage() function[1], replacing the implementation provided by UEFI. However, Shim's LoadImage() function does not implement the Security2 file authentication functionality required by SELoader.

2. GRUB 2.14 introduces memory attribute get/set APIs for NX support and enforces page permissions on loaded modules[2][3]. SELoader currently does not support setting memory attributes for NX features.

Consequently, to ensure the proper functioning of SELoader, we have had to adopt two workarounds[4][5]. As a result, we no longer recommend using SELoader. By default, a GPG key is now used to protect and verify the files utilized by GRUB.

[1] https://github.com/rhboot/shim/commit/bb114a3b92a96875dc71e5e4925bedba5c02f958
[2] https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/09ca66673ad228c736b3d46f31201065373cf866
[3] https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/94649c02670dae12c188cae471b9ae246b48f428
[4] https://github.com/Wind-River/meta-secure-core/commit/d26de315f8b6d7da8d8e84502da45758108cb0a2
[5] https://github.com/Wind-River/meta-secure-core/commit/190ac40d0b23a59408e17500a865508561f3341c