### PR TITLE
efitools: fix build error when efi-secure-boot is not in DISTRO_FEATURES

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -68,6 +68,8 @@ do_install() {
 }
 
 fakeroot python do_sign:class-target() {
+    if d.getVar('UEFI_SB') != '1':
+        return
     if d.getVar('GRUB_SIGN_VERIFY') != '1':
         return
 
@@ -76,7 +78,7 @@ fakeroot python do_sign:class-target() {
     uks_boot_sign(os.path.join(image_dir + efi_boot_path, 'LockDown.efi'), d)
 }
 addtask sign after do_install before do_deploy do_package
-do_sign[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
+do_sign[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' and d.getVar('UEFI_SB') == '1' else ''}"
 
 fakeroot python do_sign() {
 }


### PR DESCRIPTION
Commit 6d83fbf ("layer.conf: enable GRUB_SIGN_VERIFY by default instead of UEFI_SELOADER") sets GRUB_SIGN_VERIFY to 1 by default. When efi-secure-boot is not in DISTRO_FEATURES, UEFI_SB is 0, so do_install:append() in efitools_1.9.2.bb does not copy LockDown.efi to ${EFI_BOOT_PATH}. However, do_sign:class-target() in efitools.inc still attempts to sign LockDown.efi because GRUB_SIGN_VERIFY is 1, resulting in a build error:

  ERROR: Failed to sign: .../efitools/1.9.2/image/boot/efi/EFI/BOOT/LockDown.efi

Additionally, the check_boot_public_key prefunc may fail on build hosts where gpg is not available:

  ERROR: Failed to import gpg key (...): /bin/sh: 1: --batch: not found

Fix both issues by adding a UEFI_SB check to do_sign:class-target() and its prefunc condition, so that signing is only attempted when efi-secure-boot is actually enabled.

Tested the followings build pass with or without efi-secure-boot in DISTRO_FEATURES:

  bitbake efitools
  bitbake linux-yocto