### PR TITLE
key-store: Fix incorrect Python membership test syntax

### DIFF
--- a/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
+++ b/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
@@ -28,7 +28,7 @@ MODSIGN_CERT = "${KEY_DIR}/modsign_key.crt"
 IMA_CERT = "${KEY_DIR}/x509_ima.der"
 
 python () {
-    if not (uks_signing_model(d) in "sample", "user"):
+    if not uks_signing_model(d) in ("sample", "user"):
         return
 
     pn = d.getVar('PN') + '-rpm-pubkey'


### PR DESCRIPTION
The original expression `not (uks_signing_model(d) in "sample", "user")` is parsed as `not ((uks_signing_model(d) in "sample"), "user")` due to Python operator precedence. The `in` operator binds tighter than the comma, so this creates a tuple where the second element "user" is always truthy, making the `not` always evaluate to False and the function always returns early.

Change to `not uks_signing_model(d) in ("sample", "user")` which correctly tests whether the return value is a member of the tuple ("sample", "user").