### PR TITLE
meta-integrity/linux-yocto:  Copy modsign_key.pem to shared_workdir

### DIFF
--- a/meta-integrity/recipes-kernel/linux/linux-yocto-modsign.inc
+++ b/meta-integrity/recipes-kernel/linux/linux-yocto-modsign.inc
@@ -30,3 +30,9 @@ do_configure:prepend() {
         true
     fi
 }
+
+do_shared_workdir:append() {
+    if [ ${MODSIGN_ENABLED} = "1" ]; then
+        cp modsign_key.pem $kerneldir/
+    fi
+}


### PR DESCRIPTION
Copy modsign_key.pem into the kernel shared_workdir to allow out-of-tree modules built via kbuild to be signed when CONFIG_MODULE_SIG and CONFIG_MODULE_SIG_ALL are enabled.