### PR TITLE
ovmf: update for upstream FIXED_GCCVER -> TARGET_TOOLS rename

### DIFF
--- a/meta-efi-secure-boot/recipes-core/ovmf/ovmf-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-core/ovmf/ovmf-efi-secure-boot.inc
@@ -8,8 +8,8 @@ PACKAGECONFIG:append = " secureboot"
 # For SELoader
 do_compile:class-target:append() {
     if ${@bb.utils.contains('PACKAGECONFIG', 'secureboot', 'true', 'false', d)}; then
-        secbuild_dir="${S}/Build/SecurityPkg/${OVMF_BUILD_TYPE}_${FIXED_GCCVER}"
-        ${S}/OvmfPkg/build.sh $PARALLEL_JOBS -a $OVMF_ARCH -b ${OVMF_BUILD_TYPE} -t ${FIXED_GCCVER} ${PACKAGECONFIG_CONFARGS} ${OVMF_SECURE_BOOT_FLAGS} -p SecurityPkg/SecurityPkg.dsc
+        secbuild_dir="${S}/Build/SecurityPkg/${OVMF_BUILD_TYPE}_${TARGET_TOOLS}"
+        ${S}/OvmfPkg/build.sh $PARALLEL_JOBS -a $OVMF_ARCH -b ${OVMF_BUILD_TYPE} -t ${TARGET_TOOLS} ${PACKAGECONFIG_CONFARGS} ${OVMF_SECURE_BOOT_FLAGS} -p SecurityPkg/SecurityPkg.dsc
         ln ${secbuild_dir}/${OVMF_ARCH}/Hash2DxeCrypto.efi ${WORKDIR}/ovmf/
         ln ${secbuild_dir}/${OVMF_ARCH}/Pkcs7VerifyDxe.efi ${WORKDIR}/ovmf/
     fi


### PR DESCRIPTION
The openembedded-core ovmf recipe was recently updated to replace the FIXED_GCCVER variable with TARGET_TOOLS. Update the secure boot append to use the new variable name.

This fixes the following build error:
  `error 1005: Not supported target [tpm_enable=false]`

The error occurred because the stale FIXED_GCCVER reference caused the build arguments to be misinterpreted by the EDK2 build system.

See upstream openembedded-core commit [325c4b0b14731b4c1782277f49b972e2b1b55d7d](https://github.com/openembedded/openembedded-core/commit/325c4b0b14731b4c1782277f49b972e2b1b55d7d) for the original recipe changes.